### PR TITLE
Added auto insert of slashes when writing date

### DIFF
--- a/source/innomatic/core/classes/shared/wui/WuiDate.php
+++ b/source/innomatic/core/classes/shared/wui/WuiDate.php
@@ -63,9 +63,9 @@ class WuiDate extends \Innomatic\Wui\Widgets\WuiWidget
      * If not specified is set to true.
      * 
      * @var boolean
-     * @access private
+     * @access public
      */
-    private $mAutoSlash;
+    public $mAutoSlash;
 
     public function __construct (
         $elemName,


### PR DESCRIPTION
This feature is always active on the Innomatic WuiDate Widget, unless it is explicitly disabled on the widget's instance.
Currently, works only for dates with the format "dd/mm/yyyy" or "mm/dd/yyyy".