### PR TITLE
Fix default eventData with empty array if not exist

### DIFF
--- a/source/innomatic/core/classes/innomatic/wui/dispatch/WuiDispatcher.php
+++ b/source/innomatic/core/classes/innomatic/wui/dispatch/WuiDispatcher.php
@@ -119,7 +119,7 @@ class WuiDispatcher
      */
     public function getEventData()
     {
-        return isset(\Innomatic\Wui\Wui::instance('\Innomatic\Wui\Wui')->parameters['wui'][$this->mName]['evd']) ? \Innomatic\Wui\Wui::instance('\Innomatic\Wui\Wui')->parameters['wui'][$this->mName]['evd'] : '';
+        return isset(\Innomatic\Wui\Wui::instance('\Innomatic\Wui\Wui')->parameters['wui'][$this->mName]['evd']) ? \Innomatic\Wui\Wui::instance('\Innomatic\Wui\Wui')->parameters['wui'][$this->mName]['evd'] : array();
     }
 
     public static function dispatchersList()


### PR DESCRIPTION
Fix empty $eventData with an empty array if it is not set